### PR TITLE
fix: blogkit-strapi deps

### DIFF
--- a/packages/blogkit-strapi/package.json
+++ b/packages/blogkit-strapi/package.json
@@ -14,12 +14,13 @@
   "author": "colmugx",
   "license": "MIT",
   "devDependencies": {
+    "blogkit": "workspace:^",
     "typescript": "^4.5.5"
   },
   "dependencies": {
     "axios": "^0.26.0"
   },
   "peerDependencies": {
-    "blogkit": "*"
+    "blogkit": "workspace:^"
   }
 }

--- a/packages/blogkit-strapi/tsconfig.json
+++ b/packages/blogkit-strapi/tsconfig.json
@@ -14,7 +14,9 @@
 
     /* Language and Environment */
     "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": [
+      "esnext"
+    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,12 @@ importers:
   packages/blogkit-strapi:
     specifiers:
       axios: ^0.26.0
+      blogkit: workspace:^
       typescript: ^4.5.5
     dependencies:
       axios: 0.26.0
     devDependencies:
+      blogkit: link:../core
       typescript: 4.5.5
 
   packages/blogkit-theme-minimal:
@@ -64,7 +66,7 @@ importers:
       postcss: 8.4.7
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      tailwindcss: 3.0.23_iwc7stpd5lcuyf56paxiwujvfq
+      tailwindcss: 3.0.23_autoprefixer@10.4.2
       typescript: 4.5.5
 
   packages/blogkit-yuque:
@@ -481,7 +483,7 @@ packages:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
-      tailwindcss: 3.0.23_iwc7stpd5lcuyf56paxiwujvfq
+      tailwindcss: 3.0.23_autoprefixer@10.4.2
     dev: true
 
   /@types/is-ci/3.0.0:
@@ -2413,13 +2415,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tailwindcss/3.0.23_iwc7stpd5lcuyf56paxiwujvfq:
+  /tailwindcss/3.0.23_autoprefixer@10.4.2:
     resolution: {integrity: sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==}
     engines: {node: '>=12.13.0'}
     hasBin: true
     peerDependencies:
       autoprefixer: ^10.0.2
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.1
       autoprefixer: 10.4.2_postcss@8.4.7


### PR DESCRIPTION
```bash
> pnpm run dev
```
throw error:
```bash
blogkit-strapi:build: src/index.ts(2,38): error TS2307: Cannot find module 'blogkit' or its corresponding type declarations.
blogkit-strapi:build: src/index.ts(5,20): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
blogkit-strapi:build: src/index.ts(6,22): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
blogkit-strapi:build:  ELIFECYCLE  Command failed with exit code 2.
blogkit-strapi:build: ERROR: command finished with error: command (/Users/4ark/projects/blogkit/packages/blogkit-strapi) pnpm run build exited (1)
blogkit-notion:build: cache miss, executing 3182ff24fe58463f
blogkit-yuque:build: cache miss, executing 30cc34708e9efed4
blogkit-theme-minimal:build: cache miss, executing d129e85ce0707da1
command (/Users/4ark/projects/blogkit/packages/blogkit-strapi) pnpm run build exited (1)
```